### PR TITLE
Preliminary support for embedding text labels underneath QR Code image

### DIFF
--- a/src/Endroid/QrCode/Exceptions/MissingFontPathException.php
+++ b/src/Endroid/QrCode/Exceptions/MissingFontPathException.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCode\Exceptions;
+
+class MissingFontPathException extends \Exception
+{
+}


### PR DESCRIPTION
Adds support for including a label underneath the QR Code directly in the image PNG. It requires that the user set the label text and TTF font path at a minimum, and also optionally supports changing the font size away from the default of 12px, for example:
```
use Endroid\QrCode\QrCode;

$qrCode = new QrCode();
$qrCode
    ->setText("Life is too short to be generating QR codes")
    ->setSize(300)
    ->setPadding(10)
    ->setErrorCorrection('high')
    ->setForegroundColor(array('r' => 0, 'g' => 0, 'b' => 0, 'a' => 0))
    ->setBackgroundColor(array('r' => 255, 'g' => 255, 'b' => 255, 'a' => 0))
    ->setFontPath('path/to/yourfont.ttf')
    ->setFontSize(16)
    ->setLabel('image label')
    ->render()
;
```
Note that at the moment, the code does not handle any sort of word wrapping. If the label string or font size is too large for the requested image dimensions, the text is simply cut off.