### PR TITLE
Allow transparency in logos

### DIFF
--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -1534,6 +1534,10 @@ class QrCode
 
         if(!empty($this->logo))
         {
+            $output_image_org = $output_image;
+            $output_image = imagecreatetruecolor($image_width, $image_height);
+            imagecopy($output_image, $output_image_org, 0, 0, 0, 0, $image_width, $image_height);
+
             $logo_image = call_user_func('imagecreatefrom'.$this->image_type, $this->logo);
             if(!$logo_image){
                 throw new ImageFunctionFailedException('imagecreatefrom'.$this->image_type . ' ' . $this->logo . 'failed' );


### PR DESCRIPTION
This change allows you to use transparency in your logo (if you for example use an png image)
