### PR TITLE
Fix

### DIFF
--- a/src/Bundle/Twig/Extension/QrCodeExtension.php
+++ b/src/Bundle/Twig/Extension/QrCodeExtension.php
@@ -86,7 +86,7 @@ class QrCodeExtension extends Twig_Extension implements ContainerAwareInterface
      */
     protected function getQrCodeFactory()
     {
-        return $this->container->get('endroid_qrcode.factory');
+        return $this->container->get('endroid.qrcode.factory');
     }
 
     /**


### PR DESCRIPTION
Fix for return $this->container->get('endroid_qrcode.factory'), no service with such name is available