### PR TITLE
fix twig extension after changing core library

### DIFF
--- a/src/Bundle/Twig/Extension/QrCodeExtension.php
+++ b/src/Bundle/Twig/Extension/QrCodeExtension.php
@@ -66,7 +66,7 @@ class QrCodeExtension extends Twig_Extension implements ContainerAwareInterface
         $qrCode = $this->getQrCodeFactory()->createQrCode($options);
         $qrCode->setText($text);
 
-        return $qrCode->getDataUri();
+        return $qrCode->writeUri();
     }
 
     /**


### PR DESCRIPTION
getDataUri() no longer exists and it was replaced with writeUri()