### PR TITLE
Remove dependency on Sensio Framework Extra Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ This step can be skipped if you only use data URIs to display your images.
 
 ``` yml
 EndroidQrCodeBundle:
-    resource: "@EndroidQrCodeBundle/Controller/"
-    type:     annotation
+    resource: "@EndroidQrCodeBundle/Resources/config/routing.yml"
     prefix:   /qrcode
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "symfony/templating": "^2.7|^3.0",
         "symfony/twig-bundle": "^2.7|^3.0",
         "symfony/yaml": "^2.7|^3.0",
-        "sensio/framework-extra-bundle": "^3.0",
         "phpunit/phpunit": "^5.7|^6.0"
     },
     "autoload": {

--- a/src/Bundle/QrCodeBundle/Controller/QrCodeController.php
+++ b/src/Bundle/QrCodeBundle/Controller/QrCodeController.php
@@ -10,8 +10,6 @@
 namespace Endroid\QrCode\Bundle\QrCodeBundle\Controller;
 
 use Endroid\QrCode\Factory\QrCodeFactory;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,8 +20,6 @@ use Symfony\Component\HttpFoundation\Request;
 class QrCodeController extends Controller
 {
     /**
-     * @Route("/{text}.{extension}", name="endroid_qrcode_generate", requirements={"text"="[\w\W]+"})
-     *
      * @param Request $request
      * @param string  $text
      * @param string  $extension
@@ -41,16 +37,21 @@ class QrCodeController extends Controller
     }
 
     /**
-     * @Route("/twig", name="endroid_qrcode_twig_functions")
-     * @Template()
-     *
-     * @return array
+     * @return Response
      */
     public function twigFunctionsAction()
     {
-        return [
+        if (!$this->has('twig')) {
+            throw new \LogicException('You can not use the "@Template" annotation if the Twig Bundle is not available.');
+        }
+
+        $param = [
             'message' => 'QR Code',
         ];
+
+        $renderedView = $this->get('twig')->render('@EndroidQrCode/QrCode/twigFunctions.html.twig', $param);
+
+        return new Response($renderedView, Response::HTTP_OK);
     }
 
     /**

--- a/src/Bundle/QrCodeBundle/Resources/config/routing.yml
+++ b/src/Bundle/QrCodeBundle/Resources/config/routing.yml
@@ -1,0 +1,11 @@
+endroid_qrcode_generate:
+    path: /{text}.{extension}
+    requirements:
+        text: "[\\w\\W]+"
+    defaults:
+        _controller: EndroidQrCodeBundle:QrCode:generate
+
+endroid_qrcode_twig_functions:
+    path: /twig
+    defaults:
+        _controller: EndroidQrCodeBundle:QrCode:twigFunctions

--- a/tests/Bundle/app/AppKernel.php
+++ b/tests/Bundle/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
         $bundles = [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Endroid\QrCode\Bundle\QrCodeBundle\EndroidQrCodeBundle(),
         ];
 

--- a/tests/Bundle/app/bootstrap.php
+++ b/tests/Bundle/app/bootstrap.php
@@ -1,7 +1,3 @@
 <?php
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
 $loader = require __DIR__.'/../../../vendor/autoload.php';
-
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);

--- a/tests/Bundle/app/config/routing.yml
+++ b/tests/Bundle/app/config/routing.yml
@@ -1,4 +1,3 @@
 EndroidQrCodeBundle:
-    resource: "@EndroidQrCodeBundle/Controller/"
-    type: annotation
+    resource: "@EndroidQrCodeBundle/Resources/config/routing.yml"
     prefix: /qrcode


### PR DESCRIPTION
I find it kind of strange that the Sensio Framework Extra Bundle is required as a dependency for this bundle. It's only used for two things: routing (which is better done with a routing file anyway) and auto-rendering a simple template. It may make it slightly convenient there, but there are several disadvantages:

- You need the bundle to load the annotation routes, but this is not documented anywhere.
- The bundle brings an unnecessary amount of dependencies, requires special handling before tests (loading the Doctrine Annotation registry), etc.
- In projects where you don't want to (or sometimes cannot) use the bundle you have to write the routing file or even the whole controller yourself.

Which is why I decided to remove it in our fork. This makes it easier to use the QrCode routes and twig extension out of the box.

The only disadvantage of this change is that it *breaks compatibility* for anyone who uses the annotation routing at this moment. People who do this would need to import routing resource `"@EndroidQrCodeBundle/Resources/config/routing.yml"` instead of the Controller folder.