### PR TITLE
Fix missing return value in AbstractWriter

### DIFF
--- a/src/Writer/AbstractWriter.php
+++ b/src/Writer/AbstractWriter.php
@@ -23,7 +23,7 @@ abstract class AbstractWriter implements WriterInterface
     public function writeFile(QrCodeInterface $qrCode, string $path): string
     {
         $string = $this->writeString($qrCode);
-        file_put_contents($path, $string);
+        return file_put_contents($path, $string);
     }
 
     public static function supportsExtension(string $extension): bool


### PR DESCRIPTION
Type error: Return value of Endroid\QrCode\Writer\AbstractWriter::writeFile() must be of the type string, none returned