### PR TITLE
Split of the twig extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,16 @@
         "myclabs/php-enum": "^1.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0"
+        "phpunit/phpunit": "^5.7|^6.0",
+        "twig/twig": "^1.34.2|^2.4.4",
+        "symfony/phpunit-bridge": "^3.0|^4.0",
+        "symfony/routing": "^3.0|^4.0"
+    },
+    "suggest": {
+        "twig/twig": "To enable the twig extension"
+    },
+    "conflict": {
+        "twig/twig": "<1.34.2||>=2.0.0,<2.4.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" colors="true">
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
     <testsuites>
         <testsuite>
             <directory suffix="Test.php">tests</directory>

--- a/src/Twig/Extension/QrCodeExtension.php
+++ b/src/Twig/Extension/QrCodeExtension.php
@@ -15,6 +15,9 @@ use Symfony\Component\Routing\RouterInterface;
 use Twig_Extension;
 use Twig_SimpleFunction;
 
+/**
+ * @deprecated as of 3.1 and will be removed in 4.0. Use the QrCodeRoutingExtension and QrCodeUriExtension instead.
+ */
 class QrCodeExtension extends Twig_Extension
 {
     private $qrCodeFactory;
@@ -35,13 +38,17 @@ class QrCodeExtension extends Twig_Extension
         ];
     }
 
-    public function qrcodeUrlFunction(string $text, array $options = []): string
+    public function qrCodeUrlFunction(string $text, array $options = []): string
     {
+        @trigger_error(sprintf('Using %s is deprecated as of 3.1 and will be removed in 4.0. Install the EndroidQrCodeBundle instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->getQrCodeReference($text, $options, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     public function qrCodePathFunction(string $text, array $options = []): string
     {
+        @trigger_error(sprintf('Using %s is deprecated as of 3.1 and will be removed in 4.0. Install the EndroidQrCodeBundle instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->getQrCodeReference($text, $options, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
@@ -56,8 +63,10 @@ class QrCodeExtension extends Twig_Extension
         return $this->router->generate('endroid_qrcode_generate', $options, $referenceType);
     }
 
-    public function qrcodeDataUriFunction(string $text, array $options = []): string
+    public function qrCodeDataUriFunction(string $text, array $options = []): string
     {
+        @trigger_error(sprintf('Using %s is deprecated as of 3.1 and will be removed in 4.0. Use %s::qrCodeDataUriFunction() instead.', __METHOD__, QrCodeUriExtension::class), E_USER_DEPRECATED);
+
         $qrCode = $this->qrCodeFactory->create($text, $options);
 
         return $qrCode->writeDataUri();

--- a/src/Twig/Extension/QrCodeUriExtension.php
+++ b/src/Twig/Extension/QrCodeUriExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCode\Twig\Extension;
+
+use Endroid\QrCode\Factory\QrCodeFactoryInterface;
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+final class QrCodeUriExtension extends Twig_Extension
+{
+    private $qrCodeFactory;
+
+    public function __construct(QrCodeFactoryInterface $qrCodeFactory)
+    {
+        $this->qrCodeFactory = $qrCodeFactory;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new Twig_SimpleFunction('qrcode_data_uri', [$this, 'qrCodeDataUriFunction']),
+        ];
+    }
+
+    public function qrCodeDataUriFunction(string $text, array $options = []): string
+    {
+        return $this->qrCodeFactory->create($text, $options)->writeDataUri();
+    }
+}

--- a/tests/Twig/Extension/QrCodeExtensionTest.php
+++ b/tests/Twig/Extension/QrCodeExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCode\Tests\Twig\Extension;
+
+use Endroid\QrCode\Factory\QrCodeFactory;
+use Endroid\QrCode\Twig\Extension\QrCodeExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class QrCodeExtensionTest extends TestCase
+{
+    /**
+     * @group legacy
+     * @expectedDeprecation Using Endroid\QrCode\Twig\Extension\QrCodeExtension::qrCodeDataUriFunction is deprecated as of 3.1 and will be removed in 4.0. Use Endroid\QrCode\Twig\Extension\QrCodeUriExtension::qrCodeDataUriFunction() instead.
+     */
+    public function testQrCodeDataUriFunction()
+    {
+        $router = $this->prophesize(RouterInterface::class);
+        $extension = new QrCodeExtension(new QrCodeFactory(), $router->reveal());
+        $this->assertStringStartsWith('data:image/png;base64,', $extension->qrCodeDataUriFunction('Foobar'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using Endroid\QrCode\Twig\Extension\QrCodeExtension::qrCodePathFunction is deprecated as of 3.1 and will be removed in 4.0. Install the EndroidQrCodeBundle instead.
+     */
+    public function testQrCodePathFunction()
+    {
+        $router = $this->prophesize(RouterInterface::class);
+        $extension = new QrCodeExtension(new QrCodeFactory(), $router->reveal());
+
+        $router
+            ->generate('endroid_qrcode_generate', ['extension' => 'png', 'text' => 'Foobar'], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/some-qr-code-path');
+
+        $this->assertSame('/some-qr-code-path', $extension->qrCodePathFunction('Foobar'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using Endroid\QrCode\Twig\Extension\QrCodeExtension::qrCodeUrlFunction is deprecated as of 3.1 and will be removed in 4.0. Install the EndroidQrCodeBundle instead.
+     */
+    public function testQrCodeUrlFunction()
+    {
+        $router = $this->prophesize(RouterInterface::class);
+        $extension = new QrCodeExtension(new QrCodeFactory(), $router->reveal());
+
+        $router
+            ->generate('endroid_qrcode_generate', ['extension' => 'png', 'text' => 'Foobar'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://some-qr-code-url');
+
+        $this->assertSame('https://some-qr-code-url', $extension->qrCodeUrlFunction('Foobar'));
+    }
+}

--- a/tests/Twig/Extension/QrCodeUriExtensionTest.php
+++ b/tests/Twig/Extension/QrCodeUriExtensionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCode\Tests\Twig\Extension;
+
+use Endroid\QrCode\Factory\QrCodeFactory;
+use Endroid\QrCode\Twig\Extension\QrCodeUriExtension;
+use PHPUnit\Framework\TestCase;
+
+class QrCodeUriExtensionTest extends TestCase
+{
+    public function testQrCodeDataUriFunction()
+    {
+        $extension = new QrCodeUriExtension(new QrCodeFactory());
+        $this->assertStringStartsWith('data:image/png;base64,', $extension->qrCodeDataUriFunction('Foobar'));
+    }
+}


### PR DESCRIPTION
This PR adds 
 - Some missing dev dependencies
 - Adds the phpunit bridge for deprecations
 - Suggests twig (and conflicts with incompatible twig versions)
 - Deprecated the QrCodeExtension
 - Added the QrCodeUriExtension
 - The QrCodeRoutingExtension will be added to the bundle as it would otherwise cause a circular dependency between the packages (due to route names).

Closes #142.