### PR TITLE
Branch 2.* "symfony/*" version >=2.7 installs latest symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,22 @@
     "require": {
         "php": ">=5.6",
         "ext-gd": "*",
-        "symfony/options-resolver": ">=2.7",
+        "symfony/options-resolver": "^2.7",
         "bacon/bacon-qr-code": "^1.0.3",
         "khanamiryan/qrcode-detector-decoder": "^1.0",
-        "symfony/property-access": ">=2.7",
+        "symfony/property-access": "^2.7",
         "myclabs/php-enum": "^1.5"
     },
     "require-dev": {
-        "symfony/asset": ">=2.7",
-        "symfony/browser-kit": ">=2.7",
-        "symfony/finder": ">=2.7",
-        "symfony/framework-bundle": ">=2.7",
-        "symfony/http-kernel": ">=2.7",
-        "symfony/templating": ">=2.7",
-        "symfony/twig-bundle": ">=2.7",
-        "symfony/yaml": ">=2.7",
-        "phpunit/phpunit": ">=5.7"
+        "symfony/asset": "^2.7",
+        "symfony/browser-kit": "^2.7",
+        "symfony/finder": "^2.7",
+        "symfony/framework-bundle": "^2.7",
+        "symfony/http-kernel": "^2.7",
+        "symfony/templating": "^2.7",
+        "symfony/twig-bundle": "^2.7",
+        "symfony/yaml": "^2.7",
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Latest symfony packages required php 7, which conflicts with QrCode 2.* branch php requirement and doesn't install on systems with php5.

Using ^ version selector instead.